### PR TITLE
fix: validate parameter types in param decorator by default

### DIFF
--- a/src/adapter-express/express-utils/decorators.ts
+++ b/src/adapter-express/express-utils/decorators.ts
@@ -1,4 +1,5 @@
 import "reflect-metadata";
+
 import { inject, injectable, decorate } from "inversify";
 import { TYPE, METADATA_KEY, PARAMETER_TYPE, HTTP_VERBS_ENUM } from "./constants";
 import type {
@@ -14,6 +15,11 @@ import type {
 
 export const injectHttpContext = inject(TYPE.HttpContext);
 
+/**
+ * Controller decorator to define a new controller
+ * @param path route path
+ * @param middleware array of middleware to be applied to all routes in the controller
+ */
 export function controller(path: string, ...middleware: Array<Middleware>) {
   return (target: NewableFunction): void => {
     const currentMetadata: ControllerMetadata = {
@@ -34,32 +40,106 @@ export function controller(path: string, ...middleware: Array<Middleware>) {
   };
 }
 
-export function all(path: string, ...middleware: Array<Middleware>): HandlerDecorator {
+/**
+ * Decorator to allow accept all HTTP methods
+ * @param path route path, wildcard
+ * @param middleware array of middleware to be applied to all routes defined in path logic
+ */
+export function All(path: string, ...middleware: Array<Middleware>): HandlerDecorator {
   return httpMethod("all", path, ...middleware);
 }
 
+/**
+ * Decorator to allow GET HTTP method
+ * @param path route path
+ * @param middleware array of middleware to be applied to the route
+ */
 export function Get(path: string, ...middleware: Array<Middleware>): HandlerDecorator {
-  return httpMethod("get", path, ...middleware);
+  return enhancedHttpMethod("get", path, ...middleware);
 }
 
+/**
+ * Decorator to allow POST HTTP method
+ * @param path route path
+ * @param middleware array of middleware to be applied to the route
+ */
 export function Post(path: string, ...middleware: Array<Middleware>): HandlerDecorator {
   return httpMethod("post", path, ...middleware);
 }
 
+/**
+ * Decorator to allow PUT HTTP method
+ * @param path route path
+ * @param middleware array of middleware to be applied to the route
+ */
 export function Put(path: string, ...middleware: Array<Middleware>): HandlerDecorator {
-  return httpMethod("put", path, ...middleware);
+  return enhancedHttpMethod("put", path, ...middleware);
 }
 
+/**
+ * Decorator to allow PATCH HTTP method
+ * @param path route path
+ * @param middleware array of middleware to be applied to the route
+ */
 export function Patch(path: string, ...middleware: Array<Middleware>): HandlerDecorator {
-  return httpMethod("patch", path, ...middleware);
+  return enhancedHttpMethod("patch", path, ...middleware);
 }
 
+/**
+ * Decorator to allow HEAD HTTP method
+ * @param path route path
+ * @param middleware array of middleware to be applied to the route
+ */
 export function Head(path: string, ...middleware: Array<Middleware>): HandlerDecorator {
   return httpMethod("head", path, ...middleware);
 }
 
+/**
+ * Decorator to allow DELETE HTTP method
+ * @param path route path
+ * @param middleware array of middleware to be applied to the route
+ */
 export function Delete(path: string, ...middleware: Array<Middleware>): HandlerDecorator {
-  return httpMethod("delete", path, ...middleware);
+  return enhancedHttpMethod("delete", path, ...middleware);
+}
+
+function enhancedHttpMethod(
+  method: keyof typeof HTTP_VERBS_ENUM,
+  path: string,
+  ...middleware: Array<Middleware>
+): HandlerDecorator {
+  return (target: DecoratorTarget, key: string): void => {
+    const metadata: ControllerMethodMetadata = {
+      key,
+      method,
+      middleware,
+      path,
+      target,
+    };
+    let metadataList: Array<ControllerMethodMetadata> = [];
+
+    if (!Reflect.hasOwnMetadata(METADATA_KEY.controllerMethod, target.constructor)) {
+      Reflect.defineMetadata(METADATA_KEY.controllerMethod, metadataList, target.constructor);
+    } else {
+      metadataList = Reflect.getOwnMetadata(
+        METADATA_KEY.controllerMethod,
+        target.constructor,
+      ) as Array<ControllerMethodMetadata>;
+    }
+    metadataList.push(metadata);
+
+    const paramsInfo: Array<unknown> = Reflect.getMetadata("design:paramtypes", target, key) || [];
+    metadataList.forEach((m) => {
+      m.middleware.unshift((req, res, next) => {
+        req.params &&
+          Object.keys(req.params).forEach((param, idx) => {
+            const type = paramsInfo[idx];
+            req.params[param] = convertToType(req.params[param], type) as string;
+          });
+        next();
+      });
+    });
+  };
 }
 
 export function httpMethod(
@@ -91,34 +171,67 @@ export function httpMethod(
   };
 }
 
-/*
- * Parameter Decorators
+/**
+ * Parameter decorator to inject the request object
+ * @returns ParameterDecorator
  */
 export const request: () => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.REQUEST);
 
+/**
+ * Parameter decorator to inject the response object
+ * @returns ParameterDecorator
+ */
 export const response: () => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.RESPONSE);
 
+/**
+ * Parameter decorator to inject parameters from the route
+ * @returns ParameterDecorator
+ */
 export const param: (paramName?: string) => ParameterDecorator = paramDecoratorFactory(
   PARAMETER_TYPE.PARAMS,
 );
 
+/**
+ * Parameter decorator to inject query parameters
+ * @returns ParameterDecorator
+ */
 export const query: (queryParamName?: string) => ParameterDecorator = paramDecoratorFactory(
   PARAMETER_TYPE.QUERY,
 );
 
+/**
+ * Parameter decorator to inject the request body
+ * @returns ParameterDecorator
+ */
 export const body: () => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.BODY);
 
+/**
+ * Parameter decorator to inject the request headers
+ * @returns ParameterDecorator
+ */
 export const headers: (headerName?: string) => ParameterDecorator = paramDecoratorFactory(
   PARAMETER_TYPE.HEADERS,
 );
 
+/**
+ * Parameter decorator to inject the request cookies
+ * @returns ParameterDecorator
+ */
 export const cookies: (cookieName?: string) => ParameterDecorator = paramDecoratorFactory(
   PARAMETER_TYPE.COOKIES,
 );
 
+/**
+ * Parameter decorator next function
+ * @returns ParameterDecorator
+ */
 export const next: () => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.NEXT);
 
-export const Principal: () => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.PRINCIPAL);
+/**
+ * Parameter decorator to inject the principal object obtained from AuthProvider
+ * @returns ParameterDecorator
+ */
+export const principal: () => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.PRINCIPAL);
 
 function paramDecoratorFactory(
   parameterType: PARAMETER_TYPE,
@@ -126,8 +239,12 @@ function paramDecoratorFactory(
   return (name?: string): ParameterDecorator => params(parameterType, name);
 }
 
-export function params(type: PARAMETER_TYPE, parameterName?: string) {
-  return (target: unknown | Controller, methodName: string | symbol, index: number): void => {
+export function params(type: PARAMETER_TYPE, parameterName?: string): ParameterDecorator {
+  return (
+    target: unknown | Controller,
+    methodName: string | symbol | undefined,
+    index: number,
+  ): void => {
     let metadataList: ControllerParameterMetadata = {};
     let parameterMetadataList: Array<ParameterMetadata> = [];
     const parameterMetadata: ParameterMetadata = {
@@ -157,4 +274,15 @@ export function params(type: PARAMETER_TYPE, parameterName?: string) {
       (target as Controller).constructor,
     );
   };
+}
+
+function convertToType(value: string, type: unknown): string | number | boolean {
+  if (type === Number) {
+    return Number(value);
+  } else if (type === String) {
+    return value;
+  } else if (type === Boolean) {
+    return value === "true" || value === "1";
+  }
+  return value;
 }


### PR DESCRIPTION
# Pull Request Guidelines

Our guidelines for submitting a pull request.

## Before submitting a Pull Request, please make sure you have verified the following:

- [x] The commit message follows our guidelines:
  - A good commit message should be two things: meaningful and concise. It should not contain every single detail, describing each changed line—we can see all the changes in Git—but, at the same time, it should say enough to avoid ambiguity.
  - We use Microverse's commit message convention
  - The convention stablish that a commit message has to be in the present tense, imperative and lowercase.
  - Example: `fix typo in README.md`
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Please describe the current behavior that you are modifying, or link to a relevant issue.
Currently `@param` decorator don't validate the type is being passed. All parameter by default are strings

Issue Number: N/A

## What is the new behavior?
Describe the new behavior or link to a relevant issue.
Now parameters are converted and validate to the type of the variable that will receive the parameter

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications below.

## Other information

Any other information that is important to this PR.