### PR TITLE
feat: returns httpServer for e2e testing with supertest

### DIFF
--- a/src/adapter-express/application-express.interface.ts
+++ b/src/adapter-express/application-express.interface.ts
@@ -1,3 +1,4 @@
+import express from "express";
 import { IApplicationMessageToConsole, RenderTemplateOptions } from "@expressots/core";
 import { ServerEnvironment } from "./application-express.types";
 
@@ -29,4 +30,10 @@ export interface IWebServerPublic {
    *                      This includes the extension name, view path, and the engine function itself.
    */
   setEngine<T extends RenderTemplateOptions>(options: T): void;
+
+  /**
+   * Get the underlying HTTP server. (default: Express.js)
+   * @returns The underlying HTTP server after initialization.
+   */
+  getHttpServer(): Promise<express.Application>;
 }


### PR DESCRIPTION
# Pull Request Guidelines

Our guidelines for submitting a pull request.

## Before submitting a Pull Request, please make sure you have verified the following:

- [x] The commit message follows our guidelines:
  - A good commit message should be two things: meaningful and concise. It should not contain every single detail, describing each changed line—we can see all the changes in Git—but, at the same time, it should say enough to avoid ambiguity.
  - We use Microverse's commit message convention
  - The convention stablish that a commit message has to be in the present tense, imperative and lowercase.
  - Example: `fix typo in README.md`
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Please describe the current behavior that you are modifying, or link to a relevant issue.
No support for supertest e2e testing as the app express are not exposed

Issue Number: N/A

## What is the new behavior?
Describe the new behavior or link to a relevant issue.

created a method called `getHttpServer` that returns a proxy to the app express limiting the function to only work with supertest


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications below.

## Other information

Any other information that is important to this PR.