### PR TITLE
Fix/param id http decorator failing

### DIFF
--- a/src/adapter-express/express-utils/decorators.ts
+++ b/src/adapter-express/express-utils/decorators.ts
@@ -44,12 +44,8 @@ export function controller(path: string, ...middleware: Array<Middleware>) {
         const realPath =
           pathMetadata[key]["path"] === "/" ? path : `${path}${pathMetadata[key]["path"]}`;
 
-        if (statusCodePathMapping[realPath]) {
-          statusCodePathMapping[`${realPath}/-${pathMetadata[key]["method"].toLowerCase()}`] =
-            statusCodeMetadata[key];
-        } else {
-          statusCodePathMapping[realPath] = statusCodeMetadata[key];
-        }
+        statusCodePathMapping[`${realPath}/-${pathMetadata[key]["method"].toLowerCase()}`] =
+          statusCodeMetadata[key];
       }
     }
 

--- a/src/adapter-express/express-utils/decorators.ts
+++ b/src/adapter-express/express-utils/decorators.ts
@@ -34,21 +34,19 @@ export function controller(path: string, ...middleware: Array<Middleware>) {
       target,
     };
 
-    const pathMetadata = Reflect.getOwnMetadata(HTTP_CODE_METADATA.path, Reflect);
-    const statusCodeMetadata = Reflect.getOwnMetadata(HTTP_CODE_METADATA.statusCode, Reflect);
-
-    let statusCodePathMapping = Reflect.getOwnMetadata(HTTP_CODE_METADATA.httpCode, Reflect);
-
-    if (!statusCodePathMapping) {
-      statusCodePathMapping = {};
-    }
+    const pathMetadata = Reflect.getOwnMetadata(HTTP_CODE_METADATA.path, Reflect) || {};
+    const statusCodeMetadata = Reflect.getOwnMetadata(HTTP_CODE_METADATA.statusCode, Reflect) || {};
+    const statusCodePathMapping =
+      Reflect.getOwnMetadata(HTTP_CODE_METADATA.httpCode, Reflect) || {};
 
     for (const key in pathMetadata) {
       if (statusCodeMetadata && statusCodeMetadata[key]) {
-        let realPath = pathMetadata[key]["path"] === "/" ? path : `${path}${pathMetadata[key]["path"]}`;
+        const realPath =
+          pathMetadata[key]["path"] === "/" ? path : `${path}${pathMetadata[key]["path"]}`;
 
         if (statusCodePathMapping[realPath]) {
-          statusCodePathMapping[`${realPath}/-${pathMetadata[key]["method"].toLowerCase()}`] = statusCodeMetadata[key];
+          statusCodePathMapping[`${realPath}/-${pathMetadata[key]["method"].toLowerCase()}`] =
+            statusCodeMetadata[key];
         } else {
           statusCodePathMapping[realPath] = statusCodeMetadata[key];
         }
@@ -188,13 +186,13 @@ function enhancedHttpMethod(
     if (pathMetadata) {
       pathMetadata[key] = {
         path,
-        method
+        method,
       };
     } else {
       pathMetadata = {};
       pathMetadata[key] = {
         path,
-        method
+        method,
       };
     }
 
@@ -251,13 +249,13 @@ export function httpMethod(
     if (pathMetadata) {
       pathMetadata[key] = {
         path,
-        method
+        method,
       };
     } else {
       pathMetadata = {};
       pathMetadata[key] = {
         path,
-        method
+        method,
       };
     }
 

--- a/src/adapter-express/express-utils/decorators.ts
+++ b/src/adapter-express/express-utils/decorators.ts
@@ -45,8 +45,13 @@ export function controller(path: string, ...middleware: Array<Middleware>) {
 
     for (const key in pathMetadata) {
       if (statusCodeMetadata && statusCodeMetadata[key]) {
-        const realPath = pathMetadata[key] === "/" ? path : `${path}${pathMetadata[key]}`;
-        statusCodePathMapping[realPath] = statusCodeMetadata[key];
+        let realPath = pathMetadata[key]["path"] === "/" ? path : `${path}${pathMetadata[key]["path"]}`;
+
+        if (statusCodePathMapping[realPath]) {
+          statusCodePathMapping[`${realPath}/-${pathMetadata[key]["method"].toLowerCase()}`] = statusCodeMetadata[key];
+        } else {
+          statusCodePathMapping[realPath] = statusCodeMetadata[key];
+        }
       }
     }
 
@@ -181,10 +186,16 @@ function enhancedHttpMethod(
     let pathMetadata = Reflect.getOwnMetadata(HTTP_CODE_METADATA.path, Reflect);
 
     if (pathMetadata) {
-      pathMetadata[key] = path;
+      pathMetadata[key] = {
+        path,
+        method
+      };
     } else {
       pathMetadata = {};
-      pathMetadata[key] = path;
+      pathMetadata[key] = {
+        path,
+        method
+      };
     }
 
     Reflect.defineMetadata(HTTP_CODE_METADATA.path, pathMetadata, Reflect);
@@ -238,10 +249,16 @@ export function httpMethod(
     let pathMetadata = Reflect.getOwnMetadata(HTTP_CODE_METADATA.path, Reflect);
 
     if (pathMetadata) {
-      pathMetadata[key] = path;
+      pathMetadata[key] = {
+        path,
+        method
+      };
     } else {
       pathMetadata = {};
-      pathMetadata[key] = path;
+      pathMetadata[key] = {
+        path,
+        method
+      };
     }
 
     Reflect.defineMetadata(HTTP_CODE_METADATA.path, pathMetadata, Reflect);

--- a/src/adapter-express/express-utils/http-status-middleware.ts
+++ b/src/adapter-express/express-utils/http-status-middleware.ts
@@ -26,11 +26,7 @@ export class HttpStatusCodeMiddleware extends ExpressoMiddleware {
     if (statusCode) {
       res.status(statusCode);
     } else {
-      const patternMatchStatusCode = this.findMatchingParameterPath(
-        path,
-        statusCodeMapping,
-        formattedMethod,
-      );
+      const patternMatchStatusCode = this.findMatchingParameterPath(path, statusCodeMapping);
 
       if (patternMatchStatusCode) {
         res.status(patternMatchStatusCode);
@@ -48,11 +44,7 @@ export class HttpStatusCodeMiddleware extends ExpressoMiddleware {
    * @param method - The method to check.
    * @returns The status code if found, otherwise null.
    **/
-  private findMatchingParameterPath(
-    path: string,
-    mapping: Record<string, number>,
-    method: string,
-  ): number | null {
+  private findMatchingParameterPath(path: string, mapping: Record<string, number>): number | null {
     for (const pathCode in mapping) {
       const patternCheck = new RegExp("^" + pathCode.replace(/:[^\s/]+/g, "([^/]+)") + "$");
 

--- a/src/adapter-express/express-utils/http-status-middleware.ts
+++ b/src/adapter-express/express-utils/http-status-middleware.ts
@@ -12,13 +12,16 @@ export class HttpStatusCodeMiddleware extends ExpressoMiddleware {
   use(req: Request, res: Response, next: NextFunction): void | Promise<void> {
     const statusCodeMapping = Reflect.getMetadata(HTTP_CODE_METADATA.httpCode, Reflect);
     let path = req.path.endsWith("/") ? req.path.slice(0, -1) : req.path;
+    const formattedMethod = req.method.toLowerCase();
+
     console.log("status code mapping", statusCodeMapping);
     if (path === "/" || path === "") {
       path = "/";
     }
 
-    const statusCode =
-      statusCodeMapping[`${path}/-${req.method.toLowerCase()}`] || statusCodeMapping[path];
+    path = `${path}/-${formattedMethod}`;
+
+    const statusCode = statusCodeMapping[path];
 
     if (statusCode) {
       res.status(statusCode);
@@ -26,7 +29,7 @@ export class HttpStatusCodeMiddleware extends ExpressoMiddleware {
       const patternMatchStatusCode = this.findMatchingParameterPath(
         path,
         statusCodeMapping,
-        req.method.toLowerCase(),
+        formattedMethod,
       );
 
       if (patternMatchStatusCode) {
@@ -54,7 +57,7 @@ export class HttpStatusCodeMiddleware extends ExpressoMiddleware {
       const patternCheck = new RegExp("^" + pathCode.replace(/:[^\s/]+/g, "([^/]+)") + "$");
 
       if (patternCheck.test(path)) {
-        return mapping[`${pathCode}/-${method}`] || mapping[pathCode];
+        return mapping[pathCode];
       }
     }
 

--- a/src/adapter-express/express-utils/http-status-middleware.ts
+++ b/src/adapter-express/express-utils/http-status-middleware.ts
@@ -16,7 +16,7 @@ export class HttpStatusCodeMiddleware extends ExpressoMiddleware {
     if (path === "/" || path === "") {
       path = "/";
     }
-
+    // branch
     const statusCode = statusCodeMapping[path];
 
     if (statusCode) {

--- a/src/adapter-express/express-utils/http-status-middleware.ts
+++ b/src/adapter-express/express-utils/http-status-middleware.ts
@@ -12,19 +12,37 @@ export class HttpStatusCodeMiddleware extends ExpressoMiddleware {
   use(req: Request, res: Response, next: NextFunction): void | Promise<void> {
     const statusCodeMapping = Reflect.getMetadata(HTTP_CODE_METADATA.httpCode, Reflect);
     let path = req.path.endsWith("/") ? req.path.slice(0, -1) : req.path;
-
+    console.log("status code mapping: ", statusCodeMapping);
     if (path === "/" || path === "") {
       path = "/";
     }
-    // branch
-    const statusCode = statusCodeMapping[path];
+
+    const statusCode = statusCodeMapping[`${path}/-${req.method.toLowerCase()}`] |  statusCodeMapping[path];
 
     if (statusCode) {
       res.status(statusCode);
     } else {
-      this.setDefaultStatusCode(req, res);
+      const patternMatchStatusCode = this.findMatchingParameterPath(path, statusCodeMapping, req.method.toLowerCase());
+
+      if (patternMatchStatusCode) {
+        res.status(patternMatchStatusCode);
+      } else {
+        this.setDefaultStatusCode(req, res);
+      }
     }
     next();
+  }
+
+  private findMatchingParameterPath(path, mapping, method) {
+    for (let pathCode in mapping) {
+      const patternCheck = new RegExp('^' + pathCode.replace(/:[^\s/]+/g, '([^/]+)') + '$');
+
+      if (patternCheck.test(path)) {
+        return mapping[`${pathCode}/-${method}`] || mapping[pathCode];
+      }
+    }
+
+    return null;
   }
 
   private setDefaultStatusCode(req: Request, res: Response): void {


### PR DESCRIPTION
# Pull Request Guidelines

Our guidelines for submitting a pull request.

## Before submitting a Pull Request, please make sure you have verified the following:

- [x] The commit message follows our guidelines:
  - A good commit message should be two things: meaningful and concise. It should not contain every single detail, describing each changed line—we can see all the changes in Git—but, at the same time, it should say enough to avoid ambiguity.
  - We use Microverse's commit message convention
  - The convention stablish that a commit message has to be in the present tense, imperative and lowercase.
  - Example: `fix typo in README.md`
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Please describe the current behavior that you are modifying, or link to a relevant issue.
`@Http` decorator no setting the status when used combined with the `@param` decorator

Issue Number: N/A

## What is the new behavior?
Describe the new behavior or link to a relevant issue.
- Different HTTP Methods can set status for the same route
- In a MVC pattern where multiple routes are in the same controller `@http` decorator respects the top down order of the endpoints
- `@Http` decorator can recognize what is a static route and what is a parameter

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications below.

## Other information

Any other information that is important to this PR.